### PR TITLE
[Editorial] 'that May be only' -> 'that may be only'

### DIFF
--- a/src/epub/text/chapter-4.xhtml
+++ b/src/epub/text/chapter-4.xhtml
@@ -164,7 +164,7 @@
 			<p>He joined it once again, and, wondering why and whither he had gone, accompanied it until they reached an iron gate. He paused to look round before entering.</p>
 			<p>A churchyard. Here, then, the wretched man, whose name he had now to learn, lay underneath the ground. It was a worthy place. Walled in by houses; overrun by grass and weeds, the growth of vegetation’s death, not life; choked up with too much burying; fat with repleted appetite. A worthy place!</p>
 			<p>The spirit stood among the graves, and pointed down to one. He advanced towards it trembling. The phantom was exactly as it had been, but he dreaded that he saw new meaning in its solemn shape.</p>
-			<p>“Before I draw nearer to that stone to which you point,” said Scrooge, “answer me one question. Are these the shadows of the things that will be, or are they shadows of the things that May be only?”</p>
+			<p>“Before I draw nearer to that stone to which you point,” said Scrooge, “answer me one question. Are these the shadows of the things that will be, or are they shadows of the things that may be only?”</p>
 			<p>Still the ghost pointed downward to the grave by which it stood.</p>
 			<p>“Men’s courses will foreshadow certain ends, to which, if persevered in, they must lead,” said Scrooge. “But if the courses be departed from, the ends will change. Say it is thus with what you show me!”</p>
 			<p>The spirit was immovable as ever.</p>


### PR DESCRIPTION
In the original scans, there is a great deal of capitalization of various words that Dickens wanted to emphasis. Most were lower cased by the ebook producer, somewhat worryingly outside of [Editorial] commits. This one was missed, however. [Scans here](https://archive.org/details/christmascarol00dick2/page/n207/mode/2up).